### PR TITLE
convert git://github.com SRC_URIs to use https

### DIFF
--- a/recipes-core/jdepend/jdepend_2.9.1.bb
+++ b/recipes-core/jdepend/jdepend_2.9.1.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f5777d32a7709d558c2877d4a6616230"
 
 HOMEPAGE = "https://github.com/clarkware/jdepend"
 
-SRC_URI = "git://github.com/clarkware/jdepend"
+SRC_URI = "git://github.com/clarkware/jdepend;protocol=https"
 SRCREV = "57980590313a5dbde236a3eb2c8958e9e53e6a10"
 S = "${WORKDIR}/git"
 

--- a/recipes-core/xml-commons/jaxen_1.1.6.bb
+++ b/recipes-core/xml-commons/jaxen_1.1.6.bb
@@ -15,7 +15,7 @@ DEPENDS = "fastjar-native virtual/javac-native xerces-j xom"
 SRCREV = "7d7755ac8b19daa2ff6f319f432b864cc72d89b6"
 
 SRC_URI = "\
-        git://github.com/codehaus/${BPN} \
+        git://github.com/codehaus/${BPN};protocol=https \
         http://www.jdom.org/dist/binary/archive/jdom-1.1.tar.gz;name=jdom \
 "
 SRC_URI[jdom.md5sum] = "22745cbaaddb12884ed8ee09083d8fe2"

--- a/recipes-core/xml-commons/xom_1.2.10.bb
+++ b/recipes-core/xml-commons/xom_1.2.10.bb
@@ -14,7 +14,7 @@ PV_jaxen = "1.1.6"
 
 SRC_URI = "\
 	http://www.cafeconleche.org/XOM/${P}-src.tar.gz;name=archive \
-	git://github.com/codehaus/${SRCNAME_jaxen};name=jaxen \
+	git://github.com/codehaus/${SRCNAME_jaxen};name=jaxen;protocol=https \
 	file://04_remove_sun_import.patch \
 "
 SRC_URI[archive.md5sum] = "9f3a2ae827a9f6826fe76e4b7b0c22b3"


### PR DESCRIPTION
Github is moving to deprecate the git:// protocol for repo access. Use a
modified version of the upstream covert-srcuris.py script to find and
fixup github source URIs in-bulk.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

# Testing
Ran the `do_fetch` tasks of `packagefeed-ni-core` and confirmed that bitbake does not report any recipes as using a `git://github.com` URI.

@ni/rtos